### PR TITLE
Removing references to 'Salon' or 'Reseller'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # logogenerator
 ----
-Logo generator for Salons/Chapter project.
+Logo generator for Chapters project.
 
 
 This site is hosted on github pages. When we push to `master` it will automatically show up on [logogenerator.singularityu.org](http://logogenerator.singularityu.org). Written in HTML/CSS/JS.

--- a/index.html
+++ b/index.html
@@ -39,12 +39,10 @@
 				<div id= "event_type_div" style="display:none;">
 					<p>Sub name</p>
 					<select class="" id='event_input' onchange="updateLayout()">
-					  <option value="Salon" selected>Salon</option>
-					  <option value="Summit">Summit</option>
+					  <option value="Summit" selected>Summit</option>
 					  <option value="Global Impact Challenge">Global Impact Challenge</option>
 					  <option value="Innovation Hub">Innovation Hub</option>
 					  <option value="Chapter">Chapter</option>
-					  <option value="Reseller">Reseller</option>
 					  <option value="Executive Program">Executive Program</option>
 					</select>
 				</div>

--- a/js/script.js
+++ b/js/script.js
@@ -52,9 +52,6 @@ function updateLayout(filename){
         if(event_input.value === "Global Impact Competition"){
         document.getElementById('textcolor_div').style.display = "inline";
         }
-        if(event_input.value === "Salon"){
-        document.getElementById('textcolor_div').style.display = "none";
-        }
         if(event_input.value === "Summit"){
         document.getElementById('textcolor_div').style.display = "none";
         }


### PR DESCRIPTION
As seen on [SCAS-313](https://singularityu.atlassian.net/browse/SCAS-313):

> Hi Support team, 
A couple of requests for http://logogenerator.singularityu.org/
Can you:
> 1) remove the terms "Reseller" and "Salon" from the logo generator
> 2) Change the logo generator to su.org, and redirect the logogenerator.singularityu.org to the new su.org one?

This PR implements the first item, but not the second.
The second item requires some additional server configuration permission, which I don't have as of now.